### PR TITLE
Fix: Clarify Editor UI instructions in Chapter 1

### DIFF
--- a/docs/courses/level-one/chapter-1.md
+++ b/docs/courses/level-one/chapter-1.md
@@ -25,11 +25,12 @@ If n8n Cloud isn't a good option for you, you can [self-host with Docker](/hosti
 
 For more details on the different ways to set up n8n, see our [platforms documentation](/choose-n8n.md#platforms).
 
-Once you have n8n running, open the Editor UI in a browser window. Log in to your n8n instance. Select **Overview** and then **Create Workflow** to view the main canvas.
+Once you have n8n running, open the Editor UI in a browser window.  
+Log in to your n8n instance. In the left sidebar, Select **Overview** and then **Create Workflow**  ad then **Personal** (or your project space). From there, you can create a new workflow.
 
 It should look like this:
+<img width="3190" height="1325" alt="image" src="https://github.com/user-attachments/assets/1d413b6b-8524-47e7-98cd-159df7b6469f" />
 
-<figure><img src="/_images/courses/level-one/chapter-one/l1-c1-editor-ui.png" alt="Editor UI" style="width:100%"><figcaption align = "center"><i>Editor UI</i></figcaption></figure>
 
 ## Editor UI settings
 


### PR DESCRIPTION
This PR updates the documentation in courses/level-one/chapter-1.md to clarify the instructions for accessing the Editor UI.

Added extended description explaining that the UI may look slightly different depending on the version of n8n.

Replaced the original short text with a more detailed explanation for new users.

Ensured the screenshot reference matches the updated context.

This change improves clarity for beginners following the course.
<img width="3190" height="1325" alt="image" src="https://github.com/user-attachments/assets/40e030bd-718e-4a1b-ac22-20c30bebe6f3" />
